### PR TITLE
Prevent sensitive vars leaking by default

### DIFF
--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -1,4 +1,6 @@
 ---
+# Do we want logging on possible sensitive params when testing and joining our domains
+adjoin_no_log: true
 # Common settings for all domains
 adjoin_sssd_homedir: '/home/%u'
 adjoin_sssd_default_shell: '/bin/bash'

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -13,6 +13,7 @@
     mode: 0644
     owner: 'root'
     group: 'root'
+  no_log: "{{ adjoin_no_log }}"
   loop:
     - {src: 'ldap.conf.j2', dest: "{{ openldap_conffile }}"}
     - {src: 'krb5.conf.j2', dest: '/etc/krb5.conf'}
@@ -26,6 +27,7 @@
     mode: 0644
     owner: 'root'
     group: 'root'
+  no_log: "{{ adjoin_no_log }}"
   loop: "{{ adjoin_domains }}"
   loop_control:
     loop_var: 'domain'
@@ -35,6 +37,7 @@
       command: "timeout 5 /usr/bin/net ads testjoin -s /etc/samba/smb_{{ domain.name }}.conf"
       changed_when: false
       loop: "{{ adjoin_domains }}"
+      no_log: "{{ adjoin_no_log }}"
       loop_control:
         loop_var: 'domain'
   rescue:
@@ -44,6 +47,7 @@
         osName="{{ ansible_distribution }}" \
         osVer="{{ ansible_distribution_version }}" \
         createcomputer={{ domain.computer_objects_path }}'
+      no_log: "{{ adjoin_no_log }}"
       loop: "{{ adjoin_domains }}"
       loop_control:
         loop_var: 'domain'
@@ -55,6 +59,7 @@
     mode: 0600
     owner: 'root'
     group: 'root'
+  no_log: "{{ adjoin_no_log }}"
   notify:
     - reconfigure redhat pam
     - reconfigure debian pam


### PR DESCRIPTION
 - [x] Add no_log to anything that uses adjoin_domains in a loop as verbose output leaks credentials to the console