### PR TITLE
Use a simpler truncate for adjoin_netbios_name

### DIFF
--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -8,7 +8,7 @@ adjoin_sssd_default_shell: '/bin/bash'
 # Please note that disabling arcfour-hmac-md5 can NOT be done without some
 # work on the AD controller's side
 adjoin_kerberos_enctypes: 'aes256-cts arcfour-hmac-md5'
-adjoin_netbios_name: "{{ ansible_hostname|truncate(15, False, '', 0) }}"
+adjoin_netbios_name: "{{ ansible_hostname[:15] }}"
 
 # Configure sudo permissions for the administrative groups in this file
 adjoin_configure_sudo: false


### PR DESCRIPTION
The number of arguments for `|truncate()` changed in jinja2, and since we just need to simply have fewer characters, we don't need the full truncate method, we can just use Python's substring notation.
As is using truncate does not seem to work as intended in Ansible 2.9 (crashes at the task to warn about NetBIOS name), while this works correctly

Sorry I missed this in my original PR! I've only been using 2.10, and just so happened to pull this down for something using 2.9 and it just crashed on me.